### PR TITLE
fix #394

### DIFF
--- a/shared/urls.js
+++ b/shared/urls.js
@@ -95,7 +95,7 @@ unblock_youku.common_urls = [
     'http://v.iask.com/v_play.php*',
     'http://v.iask.com/v_play_ipad.cx.php*',
     'http://tv.weibo.com/player/*',
-    'http://wtv.v.iask.com/*.m3u8',
+    'http://wtv.v.iask.com/*.m3u8*',
     'http://wtv.v.iask.com/mcdn.php',
     'http://video.sina.com.cn/interface/l/u/getFocusStatus.php*',
 


### PR DESCRIPTION
fix #394 
The squid server denied access without ending with asterisk in ACL text file.
example url
http://wtv.v.iask.com/player/ovs1_vod______.m3u8?fid=___&sid=___&rand=___